### PR TITLE
Allow for the horaro api to be proxied

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,39 @@
+name: Publish docker image
+on:
+    push:
+        branches: [ master ]
+jobs:
+    push_to_registry:
+
+        concurrency:
+            group: ${{ github.ref }}
+            cancel-in-progress: true
+
+        name: Publish docker image
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Check out the repo
+                uses: actions/checkout@v3
+
+            -   name: Set up QEMU
+                uses: docker/setup-qemu-action@v2
+
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v2
+
+            -   name: Login to Docker
+                uses: docker/login-action@v2
+                with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            -   name: Build and push
+                id: docker_build
+                uses: docker/build-push-action@v3
+                with:
+                    context: .
+                    push: true
+                    tags: ghcr.io/${{ github.repository_owner }}/esa-horaro-proxy:latest
+                    cache-from: type=gha
+                    cache-to: type=gha

--- a/src/fetch_horaro.go
+++ b/src/fetch_horaro.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -76,6 +78,31 @@ func FetchHoraro(endpoint string) (*HoraroResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return &response, nil
+}
+
+func FetchHoraroApi(endpoint string) (*string, error) {
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	response := buf.String()
 
 	return &response, nil
 }

--- a/src/format_horaro_endpoint.go
+++ b/src/format_horaro_endpoint.go
@@ -22,6 +22,10 @@ func FormatHoraroEndpoint(parameter string) (*string, error) {
 		return &horaroURL, nil
 	}
 
+	return ParseHoraroUrl(parameter)
+}
+
+func ParseHoraroUrl(parameter string) (*string, error) {
 	endpoint, err := url.Parse(parameter)
 	if err != nil {
 		return nil, errors.New("Can not parse URL")

--- a/src/main.go
+++ b/src/main.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/patrickmn/go-cache"
-	"github.com/rs/cors"
 )
 
 func hash(s string) string {
@@ -38,6 +37,28 @@ func getHoraro(endpoint string) (*HoraroResponse, error) {
 	log.Printf("Fetching new data for '%s' from Horaro", endpoint)
 
 	horaro, err := FetchHoraro(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	defer memoryCache.Set(endpoint, horaro, cache.DefaultExpiration)
+
+	return horaro, nil
+}
+
+func getHoraroApi(endpoint string) (*string, error) {
+	response, found := memoryCache.Get(endpoint)
+	if found {
+		horaro, ok := response.(*string)
+
+		if ok {
+			return horaro, nil
+		}
+	}
+
+	log.Printf("Fetching new data for '%s' from Horaro's api", endpoint)
+
+	horaro, err := FetchHoraroApi(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -159,15 +180,74 @@ func schedulePageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// Special use-case, does not transform the data, just proxies the api.
+func apiProxy(w http.ResponseWriter, r *http.Request) {
+	// Ignore Options request from CORS
+	if r.Method == http.MethodOptions {
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	// Get endpoint parameter from URL
+	parameter := mux.Vars(r)["endpoint"]
+	endpoint, err := ParseHoraroUrl(parameter)
+	if err != nil {
+		log.Printf("Invalid horaro link '%s': %s", parameter, err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": fmt.Sprintf("Invalid Horaro link: '%s'", err.Error()),
+		})
+		return
+	}
+
+	horaro, err := getHoraroApi(*endpoint)
+	if err != nil {
+		log.Printf("Could not find the horaro data from '%s': %s", *endpoint, err.Error())
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": "Could not find the Horaro data",
+		})
+	}
+
+	// cache for 5 minutes
+	w.Header().Set("Cache-Control", "public, max-age=300")
+
+	eTag := `"` + hash(*horaro) + `"`
+	w.Header().Set("Etag", eTag)
+	if match := r.Header.Get("If-None-Match"); match != "" {
+		if strings.Contains(match, eTag) {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, *horaro)
+}
+
+func customCorsMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Force the headers on the response, seemed to be missing during my testing
+		headers := w.Header()
+		headers.Set("Access-Control-Allow-Origin", "*")
+		headers.Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		headers.Set("Access-Control-Allow-Headers", "*")
+
+		h.ServeHTTP(w, r)
+	})
+}
+
 func main() {
 	router := mux.NewRouter()
 	router.SkipClean(true)
 	router.HandleFunc("/{version:v[12]}/esa/upcoming/{endpoint:.+}", upcomingPageHandler).Methods(http.MethodGet, http.MethodOptions)
 	router.HandleFunc("/{version:v[12]}/esa/upcoming/{endpoint:.+}", upcomingPageHandler).Queries("amount", "{amount}").Methods(http.MethodGet, http.MethodOptions)
 	router.HandleFunc("/{version:v[12]}/esa/schedule/{endpoint:.+}", schedulePageHandler).Methods(http.MethodGet, http.MethodOptions)
+	router.HandleFunc("/api_proxy/{endpoint:.+}", apiProxy).Methods(http.MethodGet, http.MethodOptions)
 
 	handler := CaselessMatcher(router)
-	handler = cors.Default().Handler(handler)
+	handler = customCorsMiddleware(handler)
 
 	// Create address for HTTP server to listen on
 	port := 8080

--- a/src/main.go
+++ b/src/main.go
@@ -56,8 +56,6 @@ func getHoraroApi(endpoint string) (*string, error) {
 		}
 	}
 
-	log.Printf("Fetching new data for '%s' from Horaro's api", endpoint)
-
 	horaro, err := FetchHoraroApi(endpoint)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For the Oengus twitch panel I needed access to the ticker endpoint of horaro's api. But since horaro does not offer cors (or caching headers) this proxy needs to be utilised.